### PR TITLE
remove un-needed account id derivation

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -58,7 +58,6 @@ pub fn development_config() -> ChainSpec {
 				get_account_id_from_seed::<sr25519::Public>("Bob"),
 				get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 				get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-				get_account_id_from_seed::<sr25519::Public>("flat reflect table identify forward west boat furnace similar million list wood"),
 			],
 			true,
 		),


### PR DESCRIPTION
It wont derive same account, as the function assumes the string is `path` instead of bip39 `mnemonic`